### PR TITLE
upgrade tests to net 5.0 and nuget packages updates

### DIFF
--- a/ExternDotnetSDK/ClusterClientIntegration/Kontur.Extern.Client.Vostok.csproj
+++ b/ExternDotnetSDK/ClusterClientIntegration/Kontur.Extern.Client.Vostok.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Vostok.ClusterClient.Core" Version="0.1.9" />
-    <PackageReference Include="Vostok.Logging.Abstractions" Version="1.0.1" />
+    <PackageReference Include="Vostok.ClusterClient.Core" Version="0.1.29" />
+    <PackageReference Include="Vostok.Logging.Abstractions" Version="1.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ExternDotnetSDK/ExternDotnetSDK/Kontur.Extern.Client.csproj
+++ b/ExternDotnetSDK/ExternDotnetSDK/Kontur.Extern.Client.csproj
@@ -18,9 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
+    <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>  
 </Project>

--- a/ExternDotnetSDK/ExternDotnetSDKTests/Kontur.Extern.Client.Tests.csproj
+++ b/ExternDotnetSDK/ExternDotnetSDKTests/Kontur.Extern.Client.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-
+    <OutputType>Library</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/ExternDotnetSDK/ExternDotnetSDKTests/Kontur.Extern.Client.Tests.csproj
+++ b/ExternDotnetSDK/ExternDotnetSDKTests/Kontur.Extern.Client.Tests.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="RestSharp" Version="106.11.7" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated unit test project to net 5.0 due to donet core 2.2/3.0 is no longer supprted. Also, all packages have been updated except Newtonsoft.Json -- this is widely used package, so it sould be updated carefully