### PR TITLE
choosing ways to send requests

### DIFF
--- a/ExternDotnetSDK/ClusterClientIntegration/Vostok.ClusterClient.Core/Clients/Common/RequestSenders/ClusterClientWrapper.cs
+++ b/ExternDotnetSDK/ClusterClientIntegration/Vostok.ClusterClient.Core/Clients/Common/RequestSenders/ClusterClientWrapper.cs
@@ -13,7 +13,7 @@ using Request = Kontur.Extern.Client.Clients.Common.Requests.Request;
 
 namespace Kontur.Extern.Client.Vostok.Vostok.ClusterClient.Core.Clients.Common.RequestSenders
 {
-    public class ClusterClientWrapper : IRequestSender
+    public class ClusterClientWrapper : _IRequestSender
     {
         private readonly IClusterClient client;
 

--- a/ExternDotnetSDK/ExternDotnetSDK/Kontur.Extern.Client.csproj
+++ b/ExternDotnetSDK/ExternDotnetSDK/Kontur.Extern.Client.csproj
@@ -24,5 +24,6 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="Vostok.ClusterClient.Core" Version="0.1.30" />
+    <PackageReference Include="Vostok.Commons.Time" Version="0.1.0" />
   </ItemGroup>  
 </Project>

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Accounts/AccountClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Accounts/AccountClient.cs
@@ -15,7 +15,7 @@ namespace Kontur.Extern.Client.Clients.Accounts
         private readonly InnerCommonClient client;
         private readonly IRequestBodySerializer requestBodySerializer;
 
-        public AccountClient(ILogger logger, IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
+        public AccountClient(ILogger logger, _IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
         {
             this.requestBodySerializer = requestBodySerializer;
             client = new InnerCommonClient(logger, requestSender);

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/InnerCommonClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/InnerCommonClient.cs
@@ -13,9 +13,9 @@ namespace Kontur.Extern.Client.Clients.Common
     internal class InnerCommonClient
     {
         protected readonly ILogger Logger;
-        protected readonly IRequestSender RequestSender;
+        protected readonly _IRequestSender RequestSender;
 
-        public InnerCommonClient(ILogger logger, IRequestSender requestSender)
+        public InnerCommonClient(ILogger logger, _IRequestSender requestSender)
         {
             Logger = logger;
             RequestSender = requestSender;

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/AuthenticationOptions.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/AuthenticationOptions.cs
@@ -1,0 +1,16 @@
+using Kontur.Extern.Client.Clients.Authentication;
+
+namespace Kontur.Extern.Client.Clients.Common.RequestSenders
+{
+    internal class AuthenticationOptions
+    {
+        public AuthenticationOptions(string apiKey, IAuthenticationProvider provider)
+        {
+            ApiKey = apiKey;
+            Provider = provider;
+        }
+
+        public string ApiKey { get; }
+        public IAuthenticationProvider Provider { get; }
+    }
+}

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/IProtocol.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/IProtocol.cs
@@ -1,0 +1,176 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Kontur.Extern.Client.Clients.Common.Requests;
+using Kontur.Extern.Client.Clients.Exceptions;
+using Kontur.Extern.Client.Models.Accounts;
+using Vostok.Clusterclient.Core;
+using Vostok.Clusterclient.Core.Model;
+using Vostok.Commons.Time;
+using RequestUrlBuilder = Vostok.Clusterclient.Core.Model.RequestUrlBuilder;
+
+namespace Kontur.Extern.Client.Clients.Common.RequestSenders
+{
+    using CCRequest=Vostok.Clusterclient.Core.Model.Request;
+
+    class ProtocolExample
+    {
+        public async Task Send(IProtocol protocol)
+        {
+            // get list
+            var accountsUrl = new RequestUrlBuilder("v1")
+                .AppendToQuery("skip", 1)
+                .AppendToQuery("take", 10)
+                .Build();
+            var response = await protocol.Get(accountsUrl).SendAsync();
+            var accountList = response.GetMessage<AccountList>();
+
+            // delete
+            var accountId = accountList.Accounts.First().Id;
+            await protocol.Delete(new Uri($"v1/{accountId}")).SendAsync();
+            
+            // create
+            var requestDto = new CreateAccountRequestDto();
+            var createAccountResponse = await protocol.Post(new Uri("v1"))
+                .WithPayload(requestDto)
+                .SendAsync();
+            var createdAccount = createAccountResponse.GetMessage<Account>();
+        }
+    } 
+    
+    interface IProtocol
+    {
+        IRequest Get(Uri url);
+        IPayloadRequest Put(Uri url);
+        IPayloadRequest Post(Uri url);
+        IRequest Delete(Uri url);
+    }
+
+    internal interface IPayloadRequest : IRequest
+    {
+        IRequest WithPayload<TRequestMessage>(TRequestMessage message);
+    }
+
+    internal interface IRequest
+    {
+        Task<IResponse> SendAsync(TimeSpan? timeout = null);
+    }
+
+    internal interface IResponse
+    {
+        TResponseMessage GetMessage<TResponseMessage>();
+    }
+
+    internal class Protocol : IProtocol, IPayloadRequest
+    {
+        private CCRequest? request; 
+        private readonly RequestSendingOptions options;
+        private readonly AuthenticationOptions authOption;
+        private readonly IClusterClient clusterClient;
+        private readonly IRequestBodySerializer serializer;
+
+        public Protocol(
+            RequestSendingOptions options, 
+            AuthenticationOptions authOption,
+            IClusterClient clusterClient,
+            IRequestBodySerializer serializer)
+        {
+            this.options = options;
+            this.authOption = authOption;
+            this.clusterClient = clusterClient;
+            this.serializer = serializer;
+        }
+
+        public IRequest Get(Uri url)
+        {
+            request = CCRequest.Get(url);
+            return this;
+        }
+
+        public IPayloadRequest Put(Uri url)
+        {
+            request = CCRequest.Put(url);
+            return this;
+        }
+
+        public IPayloadRequest Post(Uri url)
+        {
+            request = CCRequest.Post(url);
+            return this;
+        }
+
+        public IRequest Delete(Uri url)
+        {
+            request = CCRequest.Delete(url);
+            return this;
+        }
+
+        IRequest IPayloadRequest.WithPayload<TRequestMessage>(TRequestMessage message)
+        {
+            var memoryStream = new MemoryStream();
+            serializer.SerializeToJsonStream(message, memoryStream);
+            memoryStream.Position = 0;
+            Request.WithContent(new StreamContent(memoryStream));
+            return this;
+        }
+
+        async Task<IResponse> IRequest.SendAsync(TimeSpan? timeout)
+        {
+            timeout ??= Request.IsWriteRequest() ? options.DefaultWriteTimeout : options.DefaultReadTimeout;
+            var timeBudget = TimeBudget.StartNew(timeout.Value);
+
+            var sessionId = await authOption.Provider.GetSessionId(timeBudget.Remaining).ConfigureAwait(false);
+
+            var leftTimeout = timeBudget.Remaining;
+            var resultRequest = BuildRequest(Request, sessionId, leftTimeout);
+
+            var result = await clusterClient.SendAsync(resultRequest, leftTimeout).ConfigureAwait(false);
+            return new ProtocolResponse(resultRequest, result.Response.EnsureSuccessStatusCode(), serializer);
+        }
+
+        private CCRequest BuildRequest(CCRequest request, string sessionId, TimeSpan? timeout)
+        {
+            var resultRequest = request
+                .WithAuthorizationHeader(SenderConstants.AuthSidHeader, sessionId)
+                .WithHeader(SenderConstants.ApiKeyHeader, authOption.ApiKey);
+
+            return timeout == null 
+                ? resultRequest 
+                : resultRequest.WithHeader(SenderConstants.TimeoutHeader, timeout.Value.ToString("c"));
+        }
+
+        private CCRequest Request => request!;
+    }
+
+    internal class ProtocolResponse : IResponse
+    {
+        private readonly CCRequest request;
+        private readonly Response response;
+        private readonly IRequestBodySerializer serializer;
+
+        public ProtocolResponse(CCRequest request, Response response, IRequestBodySerializer serializer)
+        {
+            this.request = request;
+            this.response = response;
+            this.serializer = serializer;
+        }
+        
+        public TResponseMessage GetMessage<TResponseMessage>()
+        {
+            if (!response.HasStream)
+                throw Errors.ResponseHasToHaveBody(request.ToString(true, false));
+            if (response.Headers.ContentType != SenderConstants.MediaType) 
+                throw Errors.ResponseHasUnexpectedContentType(request.ToString(true, false), response, SenderConstants.MediaType);
+
+            var memoryStream = response.Content.ToMemoryStream();
+            return serializer.DeserializeFromJson<TResponseMessage>(memoryStream);
+        }
+    }
+
+    internal static class CCRequestExtension
+    {
+        public static bool IsWriteRequest(this CCRequest request) => !request.Method.Equals(RequestMethods.Get, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/IRequestSender.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/IRequestSender.cs
@@ -1,25 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http;
+using System;
 using System.Threading.Tasks;
-using Kontur.Extern.Client.Clients.Authentication;
 using Kontur.Extern.Client.Clients.Common.Requests;
-using Kontur.Extern.Client.Clients.Common.ResponseMessages;
 
 namespace Kontur.Extern.Client.Clients.Common.RequestSenders
 {
     public interface IRequestSender
     {
-        IAuthenticationProvider AuthenticationProvider { get; }
-        string ApiKey { get; }
-
-        Task<IResponseMessage> SendJsonAsync(Request request, TimeSpan? timeout = null);
-
-        Task<IResponseMessage> SendAsync(
-            HttpMethod method,
-            string uriPath,
-            Dictionary<string, object> uriQueryParams = null,
-            object content = null,
-            TimeSpan? timeout = null);
+        Task SendAsync(RequestBuilder requestBuilder, TimeSpan? timeout = null);
+        Task<TResponse> SendAsync<TResponse>(RequestBuilder requestBuilder, TimeSpan? timeout = null);
     }
 }

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/RequestSendingOptions.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/RequestSendingOptions.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Kontur.Extern.Client.Clients.Common.RequestSenders
+{
+    internal class RequestSendingOptions
+    {
+        // todo: specify default timeouts
+        public TimeSpan? DefaultReadTimeout { get; } = TimeSpan.FromSeconds(5);
+        public TimeSpan? DefaultWriteTimeout { get; } = TimeSpan.FromSeconds(5);
+    }
+}

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/SenderConstants.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/SenderConstants.cs
@@ -2,6 +2,7 @@
 
 namespace Kontur.Extern.Client.Clients.Common.RequestSenders
 {
+    // todo: split it into different types -- ContextTypes and HeaderNames
     public static class SenderConstants
     {
         public const string MediaType = "application/json";

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/_IRequestSender.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/_IRequestSender.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Kontur.Extern.Client.Clients.Authentication;
+using Kontur.Extern.Client.Clients.Common.Requests;
+using Kontur.Extern.Client.Clients.Common.ResponseMessages;
+
+namespace Kontur.Extern.Client.Clients.Common.RequestSenders
+{
+    public interface _IRequestSender
+    {
+        IAuthenticationProvider AuthenticationProvider { get; }
+        string ApiKey { get; }
+
+        Task<IResponseMessage> SendJsonAsync(Request request, TimeSpan? timeout = null);
+
+        Task<IResponseMessage> SendAsync(
+            HttpMethod method,
+            string uriPath,
+            Dictionary<string, object> uriQueryParams = null,
+            object content = null,
+            TimeSpan? timeout = null);
+    }
+}

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/_RequestSender.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/RequestSenders/_RequestSender.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Kontur.Extern.Client.Clients.Authentication;
+using Kontur.Extern.Client.Clients.Common.Requests;
+using Kontur.Extern.Client.Clients.Common.ResponseMessages;
+using Newtonsoft.Json;
+
+namespace Kontur.Extern.Client.Clients.Common.RequestSenders
+{
+    public class _RequestSender : _IRequestSender
+    {
+        private readonly HttpClient client;
+
+        public _RequestSender(IAuthenticationProvider authenticationProvider, string apiKey, HttpClient client)
+        {
+            AuthenticationProvider = authenticationProvider;
+            ApiKey = apiKey;
+            this.client = client;
+        }
+
+        public IAuthenticationProvider AuthenticationProvider { get; }
+        public string ApiKey { get; }
+
+        public async Task<IResponseMessage> SendJsonAsync(Request request, TimeSpan? timeout = null)
+        {
+            var httpRequestMessage = new HttpRequestMessage(ConvertHttpMethod(request.Method), request.Url);
+            await AddAuthHeaders(httpRequestMessage).ConfigureAwait(false);
+            AddJsonContent(httpRequestMessage, request);
+            if (timeout != null)
+                httpRequestMessage.Headers.Add(SenderConstants.TimeoutHeader, timeout.Value.ToString("c"));
+            var httpResponseMessage = await client.SendAsync(httpRequestMessage).ConfigureAwait(false);
+            return new ResponseMessage(httpResponseMessage);
+        }
+
+        private async Task AddAuthHeaders(HttpRequestMessage httpRequestMessage)
+        {
+            var sessionId = await AuthenticationProvider.GetSessionId().ConfigureAwait(false);
+            httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue(SenderConstants.AuthSidHeader, sessionId);
+            httpRequestMessage.Headers.Add(SenderConstants.ApiKeyHeader, ApiKey);
+        }
+
+        private void AddJsonContent(HttpRequestMessage httpRequestMessage, Request request)
+        {
+            if (request.Method == RequestMethod.Get || string.IsNullOrEmpty(request.JsonContent))
+                return;
+            httpRequestMessage.Content = new StringContent(request.JsonContent);
+            httpRequestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(SenderConstants.MediaType);
+        }
+
+        private static HttpMethod ConvertHttpMethod(RequestMethod method)
+        {
+            switch (method)
+            {
+                case RequestMethod.Get:
+                    return HttpMethod.Get;
+                case RequestMethod.Post:
+                    return HttpMethod.Post;
+                case RequestMethod.Put:
+                    return HttpMethod.Put;
+                case RequestMethod.Delete:
+                    return HttpMethod.Delete;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(method), method, null);
+            }
+        }
+
+        public async Task<IResponseMessage> SendAsync(
+            HttpMethod method,
+            string uriPath,
+            Dictionary<string, object> uriQueryParams = null,
+            object content = null,
+            TimeSpan? timeout = null)
+        {
+            var request = new HttpRequestMessage(method, GetFullUri(uriPath, uriQueryParams));
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                SenderConstants.AuthSidHeader,
+                await AuthenticationProvider.GetSessionId().ConfigureAwait(false));
+            request.Headers.Add(SenderConstants.ApiKeyHeader, ApiKey);
+            TryAddContent(content, request);
+            if (timeout != null)
+                request.Headers.Add(SenderConstants.TimeoutHeader, timeout.Value.ToString("c"));
+            return new ResponseMessage(await client.SendAsync(request).ConfigureAwait(false));
+        }
+
+        private static void TryAddContent(object content, HttpRequestMessage request)
+        {
+            if (content == null) return;
+            request.Content = new StringContent(JsonConvert.SerializeObject(content));
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue(SenderConstants.MediaType);
+        }
+
+        private static string GetFullUri(string requestUri, Dictionary<string, object> uriQueryParams) =>
+            uriQueryParams != null
+                ? $"{requestUri}?{string.Join("&", uriQueryParams.Where(x => !string.IsNullOrEmpty(x.Value?.ToString())).Select(x => $"{x.Key}={x.Value}"))}"
+                : requestUri;
+    }
+}

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/Requests/IRequestBodySerializer.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/Requests/IRequestBodySerializer.cs
@@ -1,7 +1,13 @@
-﻿namespace Kontur.Extern.Client.Clients.Common.Requests
+﻿#nullable enable
+using System.IO;
+
+namespace Kontur.Extern.Client.Clients.Common.Requests
 {
     public interface IRequestBodySerializer
     {
         string SerializeToJson<T>(T body);
+        void SerializeToJsonStream<T>(T body, Stream stream);
+
+        TResult DeserializeFromJson<TResult>(Stream stream);
     }
 }

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/Requests/RequestBodySerializer.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/Requests/RequestBodySerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿#nullable enable
+using System.IO;
 using System.Text;
 using Newtonsoft.Json;
 
@@ -6,18 +7,28 @@ namespace Kontur.Extern.Client.Clients.Common.Requests
 {
     public class RequestBodySerializer : IRequestBodySerializer
     {
+        private static  readonly UTF8Encoding Utf8NoBom = new(false, true);
         private readonly JsonSerializer jsonSerializer;
 
-        public RequestBodySerializer()
-        {
-            jsonSerializer = new JsonSerializer();
-        }
+        public RequestBodySerializer() => jsonSerializer = new JsonSerializer();
 
         public string SerializeToJson<T>(T body)
         {
             var stringBuilder = new StringBuilder();
             jsonSerializer.Serialize(new StringWriter(stringBuilder), body);
             return stringBuilder.ToString();
+        }
+
+        public void SerializeToJsonStream<T>(T body, Stream stream)
+        {
+            using var streamWriter = new StreamWriter(stream, Utf8NoBom, 1024, true);
+            jsonSerializer.Serialize(streamWriter, body);
+        }
+
+        public TResult DeserializeFromJson<TResult>(Stream stream)
+        {
+            using var streamReader = new StreamReader(stream, Utf8NoBom);
+            return jsonSerializer.Deserialize<TResult>(new JsonTextReader(streamReader));
         }
     }
 }

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/Requests/RequestBuilder.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Common/Requests/RequestBuilder.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System;
+using System.IO;
+using Kontur.Extern.Client.Clients.Common.RequestSenders;
+using Vostok.Clusterclient.Core.Model;
+
+namespace Kontur.Extern.Client.Clients.Common.Requests
+{
+    // todo: when Request will no longer need, remove this alias
+    using CCRequest=Vostok.Clusterclient.Core.Model.Request;
+
+    public readonly struct RequestBuilder
+    {
+        public static RequestBuilder Get(string url) => Get(new Uri(url, UriKind.RelativeOrAbsolute));
+        public static RequestBuilder Get(Uri url) => new(CCRequest.Get(url));
+
+        
+        public static RequestBuilder Post(string url) => Post(new Uri(url, UriKind.RelativeOrAbsolute));
+        public static RequestBuilder Post(Uri url) => new(CCRequest.Post(url));
+
+        
+        public static RequestBuilder Put(string url) => Put(new Uri(url, UriKind.RelativeOrAbsolute));
+        public static RequestBuilder Put(Uri url) => new(CCRequest.Put(url));
+
+        public static RequestBuilder Delete(string url) => Delete(new Uri(url, UriKind.RelativeOrAbsolute));
+        public static RequestBuilder Delete(Uri url) => new(CCRequest.Delete(url));
+        
+        private readonly CCRequest request;
+
+        private RequestBuilder(CCRequest request) => this.request = request;
+
+        public bool IsWriteRequest => !request.Method.Equals(RequestMethods.Get, StringComparison.OrdinalIgnoreCase);
+
+        public RequestBuilder WithUrl(string url) => WithUrl(new Uri(url, UriKind.RelativeOrAbsolute));
+
+        public RequestBuilder WithUrl(Uri url) => new(request.WithUrl(url));
+
+        public RequestBuilder WithContent(byte[] content) => new(request.WithContent(content));
+
+        public RequestBuilder WithContent(Stream stream) => new(request.WithContent(stream));
+
+        public RequestBuilder WithJson(string jsonContent) => new(request.WithContent(jsonContent).WithContentTypeHeader(SenderConstants.MediaType));
+
+        public override string ToString() => request.ToString(true, false);
+
+        internal CCRequest BuildRequest(string apiKey, string sessionId, TimeSpan? timeout)
+        {
+            var resultRequest = request
+                .WithAuthorizationHeader(SenderConstants.AuthSidHeader, sessionId)
+                .WithHeader(SenderConstants.ApiKeyHeader, apiKey);
+
+            return timeout == null 
+                ? resultRequest 
+                : resultRequest.WithHeader(SenderConstants.TimeoutHeader, timeout.Value.ToString("c"));
+        }
+    }
+}

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Docflows/DocflowsClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Docflows/DocflowsClient.cs
@@ -20,7 +20,7 @@ namespace Kontur.Extern.Client.Clients.Docflows
         private readonly InnerCommonClient client;
         private readonly IRequestBodySerializer requestBodySerializer;
 
-        public DocflowsClient(ILogger logger, IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
+        public DocflowsClient(ILogger logger, _IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
         {
             this.requestBodySerializer = requestBodySerializer;
             client = new InnerCommonClient(logger, requestSender);

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Drafts/DraftsClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Drafts/DraftsClient.cs
@@ -20,7 +20,7 @@ namespace Kontur.Extern.Client.Clients.Drafts
         private readonly InnerCommonClient client;
         private readonly IRequestBodySerializer requestBodySerializer;
 
-        public DraftsClient(ILogger logger, IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
+        public DraftsClient(ILogger logger, _IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
         {
             this.requestBodySerializer = requestBodySerializer;
             client = new InnerCommonClient(logger, requestSender);

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/DraftsBuilders/DraftsBuilderClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/DraftsBuilders/DraftsBuilderClient.cs
@@ -17,7 +17,7 @@ namespace Kontur.Extern.Client.Clients.DraftsBuilders
         private readonly InnerCommonClient client;
         private readonly IRequestBodySerializer requestBodySerializer;
 
-        public DraftsBuilderClient(ILogger logger, IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
+        public DraftsBuilderClient(ILogger logger, _IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
         {
             this.requestBodySerializer = requestBodySerializer;
             client = new InnerCommonClient(logger, requestSender);

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Events/EventsClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Events/EventsClient.cs
@@ -14,7 +14,7 @@ namespace Kontur.Extern.Client.Clients.Events
     {
         private readonly InnerCommonClient client;
 
-        public EventsClient(ILogger logger, IRequestSender requestSender) =>
+        public EventsClient(ILogger logger, _IRequestSender requestSender) =>
             client = new InnerCommonClient(logger, requestSender);
 
         public async Task<EventsPage> GetEventsAsync(int take, string fromId = "0_0", TimeSpan? timeout = null) =>

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Exceptions/ContractException.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Exceptions/ContractException.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace Kontur.Extern.Client.Clients.Exceptions
+{
+    [Serializable]
+    public class ContractException : Exception
+    {
+        public ContractException(string message)
+            : base(message)
+        {
+        }
+
+        public ContractException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected ContractException(
+            SerializationInfo info,
+            StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Exceptions/Errors.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Exceptions/Errors.cs
@@ -1,0 +1,15 @@
+using System;
+using Kontur.Extern.Client.Clients.Common.Requests;
+using Vostok.Clusterclient.Core.Model;
+
+namespace Kontur.Extern.Client.Clients.Exceptions
+{
+    internal static class Errors
+    {
+        public static Exception ResponseHasToHaveBody(string request) => 
+            new ContractException($"The response on the request {request} does not have any content.");
+
+        public static Exception ResponseHasUnexpectedContentType(string request, Response response, string expectedContentType) => 
+            new ContractException($"The response on the request {request} is expected to have content type '{expectedContentType}', but it have '{response.Headers.ContentType}'");
+    }
+}

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Organizations/OrganizationsClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Organizations/OrganizationsClient.cs
@@ -14,7 +14,7 @@ namespace Kontur.Extern.Client.Clients.Organizations
     {
         private readonly InnerCommonClient client;
 
-        public OrganizationsClient(ILogger logger, IRequestSender requestSender) =>
+        public OrganizationsClient(ILogger logger, _IRequestSender requestSender) =>
             client = new InnerCommonClient(logger, requestSender);
 
         public async Task<OrganizationBatch> GetAllOrganizationsAsync(

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Replies/RepliesClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/Clients/Replies/RepliesClient.cs
@@ -18,7 +18,7 @@ namespace Kontur.Extern.Client.Clients.Replies
         private readonly InnerCommonClient client;
         private readonly IRequestBodySerializer requestBodySerializer;
 
-        public RepliesClient(ILogger logger, IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
+        public RepliesClient(ILogger logger, _IRequestSender requestSender, IRequestBodySerializer requestBodySerializer)
         {
             this.requestBodySerializer = requestBodySerializer;
             client = new InnerCommonClient(logger, requestSender);

--- a/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/KeApiClient.cs
+++ b/ExternDotnetSDK/ExternDotnetSDK/LowLevelClient/KeApiClient.cs
@@ -18,7 +18,7 @@ namespace Kontur.Extern.Client
     public class KeApiClient : IKeApiClient
     {
         private readonly ILogger iLog;
-        private readonly IRequestSender requestSender;
+        private readonly _IRequestSender requestSender;
         private readonly IRequestBodySerializer requestBodySerializer;
 
         public KeApiClient(
@@ -27,7 +27,7 @@ namespace Kontur.Extern.Client
             string baseAddress,
             ILogger logger = null)
         {
-            requestSender = new RequestSender(
+            requestSender = new _RequestSender(
                 authenticationProvider,
                 apiKey,
                 new HttpClient {BaseAddress = new Uri(baseAddress)});
@@ -38,12 +38,12 @@ namespace Kontur.Extern.Client
 
         public KeApiClient(string apiKey, IAuthenticationProvider authenticationProvider, Uri baseAddress, ILogger logger = null)
         {
-            requestSender = new RequestSender(authenticationProvider, apiKey, new HttpClient {BaseAddress = baseAddress});
+            requestSender = new _RequestSender(authenticationProvider, apiKey, new HttpClient {BaseAddress = baseAddress});
             iLog = logger ?? new SilentLogger();
             InitializeClients();
         }
 
-        public KeApiClient(IRequestSender requestSender, ILogger logger = null)
+        public KeApiClient(_IRequestSender requestSender, ILogger logger = null)
         {
             this.requestSender = requestSender;
             iLog = logger ?? new SilentLogger();


### PR DESCRIPTION
This PR is proposition to how to send requests. To send requests to only one endpoint (outside from kontur network) it uses cluster clients ability to work with only one endpoint.
2 variants:

1.  build request with `RequestBuilder` then send through `IRequestSender.SendAsync` or `IRequestSender.SendAsync<TResponse>` if we expect a payload in a response. The problem here in naming of the method `SendAsync<TResponse>` -- to be more clear the name should be `SendAndReturnResponsePayloadAsync<TResponse>`.  Also this variant does not encapsulate requests serialization. The good things is a straightforward approach, similar to `IRequestSender`.

2. use chaining from interface `IProtocol` (work name, can be changed). Examples are in the `ProtocolExample` class. This variant is more limited, but also more stricter -- allows request payloads for Put and Post only, offers more clear api to get a payload of a response:  
  ```c#
  var response = await protocol.Get(accountsUrl).SendAsync();
  var accountList = response.GetMessage<AccountList>();
  ```
 Also this variant encapsulates serialization completely -- for read and write:  
 ```c#
 var createAccountResponse = await protocol.Post(new Uri("v1"))
                .WithPayload(new CreateAccountRequestDto {...}) // serialization
                .SendAsync();
var createdAccount = createAccountResponse.GetMessage<Account>();  // deserialisation
 ```


*OLD way to send a request in the _IRequestSender*. 

*New schemes haven't applied to concrete requests yet*.